### PR TITLE
Corrige enlace roto del blog de Reflex v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ rx.button() # Ahora este será el botón de Radix
 rx.chakra.button() # Anterior botón de Chakra
 ```
 
-Aquí tienes [un artículo](https://reflex.dev/blog/2024-02-16-reflex-v0.4.0) con toda la información sobre la nueva versión.
+Aquí tienes [un artículo](https://reflex.dev/blog/2024-02-16-reflex-v0-4-0/) con toda la información sobre la nueva versión.
 
 ## Curso de Python Web: Tutorial en vídeo
 


### PR DESCRIPTION
Reflex cambió el formato de las URLs de su blog: los puntos en los números de versión se reemplazaron por guiones. La URL anterior (/blog/2024-02-16-reflex-v0.4.0) ya no funciona.

Se actualiza a:
https://reflex.dev/blog/2024-02-16-reflex-v0-4-0/